### PR TITLE
Update expo version from 14 to 25

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "react-native-stage-0/decorator-support"
+    "react-native"
   ],
   "env": {
     "development": {

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/**/*
 .DS_Store
-.exponent
+.expo

--- a/exp.json
+++ b/exp.json
@@ -2,14 +2,13 @@
   "name": "Pomodoro",
   "description": "A pomodro timer, super fun, you can time things and pause and stop and count tomatoes.",
   "slug": "pomodoro",
-  "sdkVersion": "14.0.0",
+  "sdkVersion": "25.0.0",
   "version": "1.0.0",
   "orientation": "portrait",
   "primaryColor": "#cccccc",
   "privacy": "public",
   "icon": "./icon.png",
   "notification": {
-    "iconUrl": "https://s3.amazonaws.com/exp-us-standard/placeholder-push-icon-blue-circle.png",
     "color": "#000000"
   },
   "loading": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "src/main.js",
   "author": "brentvatne@gmail.com",
   "dependencies": {
-    "@exponent/vector-icons": "~4.0.0",
-    "exponent": "14.0.0",
-    "react": "~15.4.0",
-    "react-native": "github:exponentjs/react-native#sdk-14.0.0",
+    "@expo/vector-icons": "~4.0.0",
+    "expo": "^25.0.0",
+    "react": "16.2.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-25.0.0.tar.gz",
     "react-native-drawer-layout": "^1.1.0"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
-import Exponent, { Constants, Permissions, Notifications } from 'exponent';
+import Exponent, { Constants, Permissions, Notifications } from 'expo';
 
 import DrawerLayout from 'react-native-drawer-layout';
 


### PR DESCRIPTION
I found this project on the list of [Curated List of Open Source React Native apps](https://github.com/ReactNativeNews/React-Native-Apps), but wasn't able to run it as is. Here are some updates that allowed me to run the project.